### PR TITLE
画像投稿機能作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 /node_modules
 
 /public/.DS_Store
+/public/uploads
+
+/.env
 
 .DS_Store
 app/.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,10 @@ gem 'sorcery'
 # AWS S3による画像アップローダー用
 gem 'carrierwave'
 # S3実装時にコメントを解除
-#gem 'fog'
+gem 'fog-aws'
+
+# 環境変数の管理
+gem 'dotenv-rails'
 
 # タスク関連
 gem 'whenever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,9 +102,14 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.12.0)
+    excon (0.99.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -115,6 +120,22 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    fog-aws (3.18.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -148,10 +169,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
       date
@@ -330,8 +355,10 @@ DEPENDENCIES
   capybara
   carrierwave
   debug
+  dotenv-rails
   enum_help
   factory_bot_rails
+  fog-aws
   html2slim
   importmap-rails
   jbuilder

--- a/app/controllers/theme_boards_controller.rb
+++ b/app/controllers/theme_boards_controller.rb
@@ -19,12 +19,26 @@ class ThemeBoardsController < ApplicationController
   end
 
   def update
+    theme_board = ThemeBoard.find(params[:id])
+    if PhotoAchievement.create(theme_board_id: theme_board.id, content: theme_board_params[:content])
+      theme_board.update(complete: true)
+      redirect_to theme_board, success: '保存成功'
+    else
+      flash.now[:error] = '保存失敗'
+      render theme_board, status: :unprocessable_entity
+    end
   end
 
   def destroy
     theme_board = ThemeBoard.find(params[:id])
     theme_board.destroy!
     redirect_to theme_boards_path, success: t('.success')
+  end
+
+  private
+
+  def theme_board_params
+    params.require(:theme_board).permit(:content)
   end
 
 end

--- a/app/models/photo_achievement.rb
+++ b/app/models/photo_achievement.rb
@@ -1,3 +1,7 @@
 class PhotoAchievement < ApplicationRecord
   belongs_to :theme_board
+
+  validates :content, presence: true
+
+  mount_uploader :content, ContentUploader
 end

--- a/app/models/photo_achievement.rb
+++ b/app/models/photo_achievement.rb
@@ -1,0 +1,3 @@
+class PhotoAchievement < ApplicationRecord
+  belongs_to :theme_board
+end

--- a/app/models/theme_board.rb
+++ b/app/models/theme_board.rb
@@ -1,6 +1,7 @@
 class ThemeBoard < ApplicationRecord
   belongs_to :user
   belongs_to :themeable, polymorphic: true
+  has_one :photo_achievement, dependent: :destroy
 
   def self.set_photo_theme(id, user_id)
     # id(カテゴリ)があれば該当カテゴリでランダムに取得して代入

--- a/app/uploaders/content_uploader.rb
+++ b/app/uploaders/content_uploader.rb
@@ -3,9 +3,12 @@ class ContentUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # 本番環境ではS3にアップロード、それ以外はローカル
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/content_uploader.rb
+++ b/app/uploaders/content_uploader.rb
@@ -1,0 +1,47 @@
+class ContentUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/theme_boards/show.html.slim
+++ b/app/views/theme_boards/show.html.slim
@@ -2,12 +2,15 @@
 h1
   = "#{@theme.target}を撮影しよう"
 
+- if @theme_board.photo_achievement.present?
+  = image_tag "#{@theme_board.photo_achievement.content}", size: "300x200"
+
 div
   div
   = form_with model: @theme_board, local: true do |f|
     .form_control
       label.label
-      = f.file_field :photo_theme_img
+      = f.file_field :content
     .form_control
       = f.submit t('.judgement')
       label.label

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'free-theme-atainment-01' # 作成したバケット名を記述
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
+      path_style: true
+    }
+end

--- a/db/migrate/20230219144116_create_photo_atainments.rb
+++ b/db/migrate/20230219144116_create_photo_atainments.rb
@@ -1,0 +1,10 @@
+class CreatePhotoAtainments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :photo_atainments do |t|
+      t.belongs_to :theme_board, index: { unique: true }, null: false, foreign_key: true
+      t.string :content , null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230220001554_change_photo_atainments_to_photo_achievements.rb
+++ b/db/migrate/20230220001554_change_photo_atainments_to_photo_achievements.rb
@@ -1,0 +1,5 @@
+class ChangePhotoAtainmentsToPhotoAchievements < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :photo_atainments, :photo_achievements
+  end
+end

--- a/db/migrate/20230221011411_add_index_name_to_categories.rb
+++ b/db/migrate/20230221011411_add_index_name_to_categories.rb
@@ -1,0 +1,5 @@
+class AddIndexNameToCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/migrate/20230221011649_add_index_subject_to_theme_items.rb
+++ b/db/migrate/20230221011649_add_index_subject_to_theme_items.rb
@@ -1,0 +1,5 @@
+class AddIndexSubjectToThemeItems < ActiveRecord::Migration[7.0]
+  def change
+    add_index :theme_items, :subject, unique: true
+  end
+end

--- a/db/migrate/20230221070215_add_index_target_to_photo_themes.rb
+++ b/db/migrate/20230221070215_add_index_target_to_photo_themes.rb
@@ -1,0 +1,5 @@
+class AddIndexTargetToPhotoThemes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :photo_themes, :target, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_020453) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_20_001554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_020453) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "photo_achievements", force: :cascade do |t|
+    t.bigint "theme_board_id", null: false
+    t.string "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["theme_board_id"], name: "index_photo_achievements_on_theme_board_id", unique: true
   end
 
   create_table "photo_theme_items", force: :cascade do |t|
@@ -64,6 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_020453) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "photo_achievements", "theme_boards"
   add_foreign_key "photo_theme_items", "photo_themes"
   add_foreign_key "photo_theme_items", "theme_items"
   add_foreign_key "photo_themes", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_001554) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_070215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_001554) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
   create_table "photo_achievements", force: :cascade do |t|
@@ -43,6 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_001554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_photo_themes_on_category_id"
+    t.index ["target"], name: "index_photo_themes_on_target", unique: true
   end
 
   create_table "theme_boards", force: :cascade do |t|
@@ -60,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_001554) do
     t.string "subject", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["subject"], name: "index_theme_items_on_subject", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,28 +1,52 @@
-# Category
-Category.create!(name: "建物")
-Category.create!(name: "動物")
+# Categories
+categories = [
+  {id: 1, name: "建物"},
+  {id: 2, name: "動物"}
+]
+
+categories.each do |category|
+  Category.find_or_create_by(category)
+end
 
 # ThemeItems
-ThemeItem.create!(subject: "Tower")
-ThemeItem.create!(subject: "Bridge")
-ThemeItem.create!(subject: "Dog")
-ThemeItem.create!(subject: "Bird")
-ThemeItem.create!(subject: "Rock Dove")
-ThemeItem.create!(subject: "Temple")
-ThemeItem.create!(subject: "Japanese Architecture")
-ThemeItem.create!(subject: "Shrine")
+theme_items = [
+  {id: 1, subject: "Tower"},
+  {id: 2, subject: "Bridge"},
+  {id: 3, subject: "Dog"},
+  {id: 4, subject: "Bird"},
+  {id: 5, subject: "Rock Dove"},
+  {id: 6, subject: "Temple"},
+  {id: 7, subject: "Japanese Architecture"},
+  {id: 8, subject: "Shrine"}
+]
+
+theme_items.each do |theme_item|
+  ThemeItem.find_or_create_by(theme_item)
+end
 
 # PhotoThemes
-PhotoTheme.create!(category_id: 1, target: "神社・仏閣")
-PhotoTheme.create!(category_id: 2, target: "犬")
-PhotoTheme.create!(category_id: 1, target: "タワー")
-PhotoTheme.create!(category_id: 2, target: "ハト")
+photo_themes = [
+  {id: 1, category_id: 1, target: "神社・仏閣"},
+  {id: 2, category_id: 2, target: "犬"},
+  {id: 3, category_id: 1, target: "タワー"},
+  {id: 4, category_id: 2, target: "ハト"}
+]
+
+photo_themes.each do |photo_theme|
+  PhotoTheme.find_or_create_by(photo_theme)
+end
 
 # PhotoThemeItems
-PhotoThemeItem.create!(photo_theme_id: 1, theme_item_id: 6)
-PhotoThemeItem.create!(photo_theme_id: 1, theme_item_id: 7)
-PhotoThemeItem.create!(photo_theme_id: 1, theme_item_id: 8)
-PhotoThemeItem.create!(photo_theme_id: 2, theme_item_id: 3)
-PhotoThemeItem.create!(photo_theme_id: 3, theme_item_id: 1)
-PhotoThemeItem.create!(photo_theme_id: 4, theme_item_id: 4)
-PhotoThemeItem.create!(photo_theme_id: 4, theme_item_id: 5)
+photo_theme_items = [
+  {id: 1, photo_theme_id: 1, theme_item_id: 6},
+  {id: 2, photo_theme_id: 1, theme_item_id: 7},
+  {id: 3, photo_theme_id: 1, theme_item_id: 8},
+  {id: 4, photo_theme_id: 2, theme_item_id: 3},
+  {id: 5, photo_theme_id: 3, theme_item_id: 1},
+  {id: 6, photo_theme_id: 4, theme_item_id: 4},
+  {id: 7, photo_theme_id: 4, theme_item_id: 5}
+]
+
+photo_theme_items.each do |photo_theme_item|
+  PhotoThemeItem.find_or_create_by(photo_theme_item)
+end

--- a/spec/factories/photo_achievements.rb
+++ b/spec/factories/photo_achievements.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :photo_achievement do
+    content { "MyString" }
+  end
+end

--- a/spec/models/photo_achievements_spec.rb
+++ b/spec/models/photo_achievements_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe PhotoAtainment, type: :model do
+RSpec.describe PhotoAchievement, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/photo_achievements_spec.rb
+++ b/spec/models/photo_achievements_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PhotoAtainment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/theme_boards_spec.rb
+++ b/spec/system/theme_boards_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "ThemeBoards", type: :system do
   let(:user) { create(:user) }
-  let!(:category) { create(:category) }
+  let(:category) { create(:category) }
   let!(:photo_theme) { create(:photo_theme, category: category) }
 
   before { login_as(user) }
@@ -15,6 +15,16 @@ RSpec.describe "ThemeBoards", type: :system do
         click_button category.name
         expect(page).to have_content I18n.t('theme_boards.create.success')
         expect(page).to have_content "#{photo_theme.target}を撮影しよう"
+      end
+    end
+
+    context '作成したテーマを削除' do
+      it '削除が成功する' do
+        click_link I18n.t('theme_boards.new.title')
+        click_button category.name
+        click_link I18n.t('theme_boards.show.delete')
+        expect(page).to have_content I18n.t('theme_boards.destroy.success')
+        expect(current_path).to eq theme_boards_path
       end
     end
   end


### PR DESCRIPTION
【Add】
 - 画像投稿機能
   - 画像を投稿できる
     - 開発環境はローカルに画像を保存
     - 公開環境はS3に画像を保存

【Other】
- S3およびcarrierwaveの連携に伴う各種設定
  - 環境変数用ファイルの生成(gitには上がらない)
  - .gitignoreの追記
  - gem追記
- 一部テーブルのステータス追加
  - Category/nameへのユニーク制約
  - ThemeItem/subjectへのユニーク制約
  - PhotoTheme/targetへのユニーク制約
  - 上記に伴うseedファイルの記述の変更
- (※前回漏れ)テーマ削除機能のテストを追記
