### PR TITLE
ランダムでのテーマ作成ボタン追加およびコンプリート済み画像のダウンロード機能の追加

### DIFF
--- a/app/controllers/theme_boards_controller.rb
+++ b/app/controllers/theme_boards_controller.rb
@@ -38,6 +38,13 @@ class ThemeBoardsController < ApplicationController
     @theme_boards = current_user.theme_boards.includes(:user).where(complete: true).order(created_at: :desc)
   end
 
+  def download
+    @achievement = ThemeBoard.find(params[:id]).photo_achievement
+    filepath = @achievement.content.current_path
+    stat = File::stat(filepath)
+    send_file(filepath, :filename => @achievement.content_identifier, :length => stat.size)
+  end
+
   private
 
   def theme_board_params

--- a/app/uploaders/content_uploader.rb
+++ b/app/uploaders/content_uploader.rb
@@ -44,7 +44,12 @@ class ContentUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token}.#{file.extension}" if original_filename
+  end
+
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+  end
 end

--- a/app/views/theme_boards/_after_complete_show.html.slim
+++ b/app/views/theme_boards/_after_complete_show.html.slim
@@ -1,5 +1,8 @@
 div
   = image_tag "#{theme_board.photo_achievement.content}", size: "300x200"
+
+  = link_to 'ダウンロード', download_theme_board_path(theme_board)
+
   ul
     li
       = link_to t('defaults.theme_delete'), theme_board_path, data: { turbo_method: :delete }

--- a/app/views/theme_boards/new.html.slim
+++ b/app/views/theme_boards/new.html.slim
@@ -4,7 +4,7 @@ h1
 div
   h3
     | ランダムでテーマを作成
-  = link_to 'ランダムでテーマを作成', '#'
+  = button_to 'ランダムでテーマを作成', theme_boards_path, data: { turbo_method: :post }
 div
   h3
     | テーマを選択して作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
     collection do
       get :completed
     end
+    member do
+      get :download
+    end
   end
 
 # お試し

--- a/spec/system/theme_boards_spec.rb
+++ b/spec/system/theme_boards_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "ThemeBoards", type: :system do
         attach_file 'theme_board_content', "#{Rails.root}/spec/fixtures/images/success_judge_image.jpg"
         click_button I18n.t('defaults.judgement')
         expect(page).to have_content I18n.t('theme_boards.update.success')
-        expect(page).to have_selector("img[src$='success_judge_image.jpg']")
+        expect(page).to have_content "complete"
       end
     end
 


### PR DESCRIPTION
【Add】
 - ユーザーはランダムでテーマを作成できる
 - コンプリートした画像をダウンロードできる

【Other】
 - 画像判定機能テストの修正