### PR TITLE
レイアウト調整および多重送信の阻止設定とボタンテキストの切替設定

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,7 +11,7 @@ html.text-default-black
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
 
-  body.bg-white
+  body class="bg-white #{current_page?(root_path) ? '' : 'mb-20 md:mb-0'}"
     = render 'shared/header' unless current_page?(root_path)
     = render 'shared/flash_message'
     div class="mx-4 mb-16 sm:mx-auto #{current_page?(root_path) ? 'sm:max-w-3xl' : 'sm:max-w-xl'}"

--- a/app/views/theme_boards/_before_complete_show.html.slim
+++ b/app/views/theme_boards/_before_complete_show.html.slim
@@ -1,8 +1,12 @@
 .mb-8
-  = form_with model: theme_board, data: {turbo: false} do |f|
-    .mb-6
-      = f.file_field :content
-    = f.submit t('defaults.judgement'), class: 'default-btn default-btn-color cursor-pointer'
+  = form_with model: theme_board do |f|
+    .mb-6.max-w-xs.mx-auto
+      = f.file_field :content, class: 'w-full'
+    = f.button type: 'submit', class: 'group default-btn default-btn-color cursor-pointer' do
+      span class="block group-disabled:hidden"
+        = t('defaults.judgement')
+      span class="hidden group-disabled:block"
+        = t('defaults.under_judgement')
 ul
   li
     = link_to t('defaults.theme_retire'), theme_board_path, data: { turbo_method: :delete }

--- a/app/views/theme_boards/_theme_board.html.slim
+++ b/app/views/theme_boards/_theme_board.html.slim
@@ -2,6 +2,6 @@
     = link_to theme_board, class: "block py-6 text-sm font" do
       span class="font-normal mx-6 text-gray-500"
         = l theme_board.created_at
-      span class="font-mono py-1 px-2 border-2 border-category-#{theme_board.themeable.category.id} tracking-widest mr-6 rounded-md"
+      span class="font-mono py-1 px-2 border-2 border-deep-sky tracking-widest mr-6 rounded-md"
         = theme_board.themeable.category.name
       = "#{theme_board.themeable.target}を撮影しよう"

--- a/app/views/trials/show.html.slim
+++ b/app/views/trials/show.html.slim
@@ -13,11 +13,14 @@ h1.page-title.text-deep-sky
 
   - else
     .mb-8
-      = form_with url: trial_path, scope: :theme_board, data: {turbo: false} do |f|
-        .mb-6
-          = f.file_field :content
-        .mb-6
-          = f.submit t('defaults.judgement'), class: 'default-btn default-btn-color cursor-pointer'
-      ul
-        li
-          = link_to t('defaults.theme_retire'), root_path
+      = form_with url: trial_path, scope: :theme_board do |f|
+        .mb-6.max-w-xs.mx-auto
+          = f.file_field :content, class: 'w-full'
+        = f.button type: 'submit', class: 'group default-btn default-btn-color cursor-pointer' do
+          span class="block group-disabled:hidden"
+            = t('defaults.judgement')
+          span class="hidden group-disabled:block"
+            = t('defaults.under_judgement')
+    ul
+      li
+        = link_to t('defaults.theme_retire'), root_path

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,7 @@ ja:
     invalid_access: '不正なアクセスです'
     please_login: 'ログインしてください'
     judgement: '判定'
+    under_judgement: '判定中...'
     theme_retire: 'テーマをリタイアする'
     theme_delete: 'テーマを削除する'
     password_resets: '【Free Theme】パスワードリセットに関するご案内'

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -16,13 +16,7 @@ module.exports = {
       colors: {
         'deep-sky': '#187fc4',
         'default-black': '#333',
-        'active-yellow': '#fff9b1',
-        'category-1': '#ff4500',
-        'category-2': '#008080',
-        'category-3': '#4169e1',
-        'category-4': '#c71585',
-        'category-5': '#20b2aa',
-        'category-6': '#483d8b'
+        'active-yellow': '#fff9b1'
       },
     },
   },


### PR DESCRIPTION
【Add】
 - ユーザーはテーマ判定中、再度ボタンを押下して2重にデータを送信できない
 - ユーザーがテーマ判定ボタンの押下時、ボタンテキストが「判定中...」に切り替わる

【Other】
 - 判定中のボタンテキストをi18n化
 - カテゴリ表示ボーダーカラーを変更
 - 一部レスポンシブ表示の調整