### PR TITLE
テーマ詳細ページのアクセス権限を変更

### DIFF
--- a/app/controllers/theme_boards_controller.rb
+++ b/app/controllers/theme_boards_controller.rb
@@ -1,7 +1,9 @@
 class ThemeBoardsController < ApplicationController
+  skip_before_action :require_login, only: %i[show]
   before_action :set_category, only: %i[index new completed]
   before_action :set_theme_board, only: %i[show update destroy]
-  before_action :unauthorised_user, only: %i[show update destroy]
+  before_action :unauthorised_user, only: %i[update destroy]
+  before_action :acceptable_if_complete, only: %i[show]
 
   def index
     @theme_boards = if (category_id = params[:category_id])
@@ -87,6 +89,16 @@ class ThemeBoardsController < ApplicationController
       URI.parse(file.content_url)
     else
       File.open(file.content.path)
+    end
+  end
+
+  def acceptable_if_complete
+    if @theme_board.complete == false
+      if logged_in? == false
+        redirect_to theme_boards_path, error: t('defaults.invalid_access')
+      else
+        unauthorised_user
+      end
     end
   end
 end

--- a/app/models/theme_board.rb
+++ b/app/models/theme_board.rb
@@ -45,7 +45,7 @@ class ThemeBoard < ApplicationRecord
   # タイトルの埋め込み処理
   def embedding(image)
     require 'mini_magick'
-    base_image = MiniMagick::Image.open("#{image.path}")
+    base_image = MiniMagick::Image.open(image.path.to_s)
     base_image.combine_options do |config|
       config.font './app/assets/fonts/MPLUS1-SemiBold.ttf'.freeze
       config.fill '#333333'

--- a/app/views/theme_boards/_after_complete_show.html.slim
+++ b/app/views/theme_boards/_after_complete_show.html.slim
@@ -1,7 +1,23 @@
 .mb-8
   = image_tag "#{theme_board.photo_achievement.content}", width: "300", class: "block mx-auto mb-6"
-  = link_to 'ダウンロード', download_theme_board_path(theme_board), class: 'default-btn default-btn-color'
+  - if logged_in? == true
+    - if current_user.id == @theme_board.user_id
+      = link_to 'ダウンロード', download_theme_board_path(theme_board), class: 'default-btn default-btn-color inline-block mb-6'
+      p
+        = link_to("https://twitter.com/share?url=#{request.url}&text=%0a%0a「テーマ：#{@theme.target}を撮影しよう」を達成!!", title: 'Twitter', target: '_blank', class: 'border border-twitter p-2 m-auto text-twitter rounded-full hover:bg-twitter hover:text-white') do
+          i.fa-brands.fa-twitter.pl-2
+          span.px-2
+            | Twitterに共有
+        ul.mt-8
+          li
+            = link_to t('defaults.theme_delete'), theme_board_path, data: { turbo_method: :delete }
 
-ul
-  li
-    = link_to t('defaults.theme_delete'), theme_board_path, data: { turbo_method: :delete }
+    - else
+      p.text-center.mb-4
+        | #{current_user.name}さんもテーマを達成して、画像をシェアしよう！
+      = link_to "#{t('theme_boards.new.title')}はこちら", new_theme_board_path
+  - else
+    p.text-center.mb-2
+      | 会員登録をしてテーマにチャレンジしよう！
+    p.text-center
+      = link_to "#{t('users.new.title')}はこちら", signup_path

--- a/app/views/theme_boards/completed.html.slim
+++ b/app/views/theme_boards/completed.html.slim
@@ -12,7 +12,7 @@ h1.page-title.text-deep-sky
   = turbo_frame_tag "theme_board_list" do
     ul.flex.flex-wrap
       - @categories.each do |category|
-        li.w-1/6.mb-6
+        li.w-1/4.mb-6.sm:w-1/6
           = button_to category.name, completed_theme_boards_path, {method: :get, class: 'default-btn block default-btn-color py-5 mx-auto font-bold text-deep-sky', params: {category_id: category.id} }
     .mb-8
       - if @theme_boards.present?

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -16,7 +16,8 @@ module.exports = {
       colors: {
         'deep-sky': '#187fc4',
         'default-black': '#333',
-        'active-yellow': '#fff9b1'
+        'active-yellow': '#fff9b1',
+        'twitter': '#1da1f2'
       },
     },
   },


### PR DESCRIPTION
【Add】
 - ログインしていないユーザーでも達成済みのテーマ詳細ページであればアクセスできるように権限を調整
   - ログインしていないユーザーとログインしている別ユーザーのアクセスで表示を切り替え
   - 未達成のテーマ詳細ページはこれまで同様のアクセス制限がかかるように調整

【Other】
 - コンプリート一覧画面の一部表示を調整